### PR TITLE
Makes bash scripts more portable across different Unix-like systems

### DIFF
--- a/killer.sh
+++ b/killer.sh
@@ -7,7 +7,7 @@ function stopall {
 
 function killer {
   trap stopall SIGINT SIGTERM
-  while /bin/true ; do
+  while $(which true) ; do
     sleep 600
     if [ -n "$STOP" ]; then
       break

--- a/stress_test.sh
+++ b/stress_test.sh
@@ -56,7 +56,7 @@ function run_raw_tests {
 }
 
 
-#while /bin/true; do
+#while $(which true); do
   run_ws_tests &
   run_ws_tests &
   run_ws_tests &

--- a/stress_test.sh
+++ b/stress_test.sh
@@ -25,7 +25,7 @@ function run_cmd_tests {
   X=0
   while [ $X -lt $COUNT ]; do
      X=$[$X + 1]
-     ts=$(date --utc +%Y%m%dT%H:%M:%S.%N)
+     ts=$(date -u +%Y%m%dT%H:%M:%S.%N)
      tmpfile=stress_test_results/${kind}/${kind}.${ts}
      ts_start=$(date +%s)
      $cmd >> ${tmpfile} 2>&1


### PR DESCRIPTION
The couple commits that comprise this PR are small changes which attempt to make the scripts more portable across systems.  Specifically, I ran into problems running the stress test on a Mac OSX machine.  These changes allowed the stress test to run fine on the Mac OSX system and should also work on pretty much any Unix-like machine.
